### PR TITLE
Issue 59 history tool date fix

### DIFF
--- a/src/clojure/staircase/views/footer.clj
+++ b/src/clojure/staircase/views/footer.clj
@@ -3,7 +3,7 @@
               [hiccup.element :refer (link-to unordered-list mail-to)]))
 
 (defn snippet [config]
-  [:section.footer.dark {:ng-controller "FooterCtrl"}
+  [:section.footer.dark.container-fluid {:ng-controller "FooterCtrl"}
    [:div.row
     [:div.col-sm-8.site-map
      [:ul

--- a/src/coffee/filters.coffee
+++ b/src/coffee/filters.coffee
@@ -51,8 +51,15 @@ define (require) ->
       rDate = "a moment ago"
 
     if rDate
-      rDate = filters('date')(str) + " (" +rDate + ")"
+      rDate = filters('imDate')(str) + " (" +rDate + ")"
     else
-      rDate = filters('date')(str)
+      rDate = filters('imDate')(str)
+
+  Filters.filter 'imDate', Array '$filter', (filters) -> (str) ->
+    #todo: make this match the format  2014-01-08 13:14
+    #use this: https://docs.angularjs.org/api/ng/filter/date
+    imDateFilter = filters('date')
+    theDate = new Date str
+    imDateFilter theDate, 'yyyy-MM-dd HH:mm'
 
   return Filters

--- a/src/coffee/filters.coffee
+++ b/src/coffee/filters.coffee
@@ -23,6 +23,10 @@ define (require) ->
     return obj unless obj instanceof Object
     (Object.defineProperty v, '$key', {__proto__: null, value: k} for k, v of obj)
 
+    ###*
+     * Adds rough temporal relativity to date, e.g. "3 hours ago". Doesn't add anything to dates older than yesterday.
+     * @return {String}         imDate string, with temporal relative description if applicable
+    ###
   Filters.filter 'roughDate', Array '$filter', (filters) -> (str) ->
     date = new Date str
     now = new Date()
@@ -55,9 +59,16 @@ define (require) ->
     else
       rDate = filters('imDate')(str)
 
+  ###*
+   * the imDate filter outputs dates in the format YYYY-MM-DD HH:mm.
+   * This should be the default date standard used throughout Steps.
+   * (Unfortunately there's no way in angular to set the default
+   * format for the vanilla 'date' filter).
+   * @param  {dateString} str the date to format, suitable for initialising via new Date()
+   * @return {String}         returns date matching format YYYY-MM-DD HH:mm.
+  ###
+
   Filters.filter 'imDate', Array '$filter', (filters) -> (str) ->
-    #todo: make this match the format  2014-01-08 13:14
-    #use this: https://docs.angularjs.org/api/ng/filter/date
     imDateFilter = filters('date')
     theDate = new Date str
     imDateFilter theDate, 'yyyy-MM-dd HH:mm'

--- a/src/coffee/filters.coffee
+++ b/src/coffee/filters.coffee
@@ -26,28 +26,33 @@ define (require) ->
   Filters.filter 'roughDate', Array '$filter', (filters) -> (str) ->
     date = new Date str
     now = new Date()
+    rDate;
 
     minutesAgo = (now.getTime() - date.getTime()) / 60 / 1000
-
-    if minutesAgo < 1
-      return "a moment ago"
-
-    if minutesAgo < 2
-      return "one minute ago"
-    
-    if minutesAgo < 60
-      return "today, #{ minutesAgo.toFixed() } minutes ago"
-
     hoursAgo = minutesAgo / 60
-
-    if hoursAgo < now.getHours()
-      return "today, #{ hoursAgo.toFixed() } hours ago"
-
     daysAgo = hoursAgo / 24
 
-    if hoursAgo > (1 + (now.getHours() / 24))
-      return filters('date')(str)
+    if hoursAgo < 48 && (now.getDate()-1 == date.getDate())
+      rDate = "yesterday"
+
+    if hoursAgo < now.getHours()
+      if hoursAgo.toFixed() == "1"
+        rDate = "today, one hour ago"
+      else
+        rDate = "today, #{ hoursAgo.toFixed() } hours ago"
+
+    if minutesAgo < 60
+      rDate =  "today, #{ minutesAgo.toFixed() } minutes ago"
+
+    if minutesAgo < 2
+      rDate = "one minute ago"
+
+    if minutesAgo < 1
+      rDate = "a moment ago"
+
+    if rDate
+      rDate = filters('date')(str) + " (" +rDate + ")"
     else
-      return "yesterday"
+      rDate = filters('date')(str)
 
   return Filters

--- a/src/coffee/filters.coffee
+++ b/src/coffee/filters.coffee
@@ -37,12 +37,12 @@ define (require) ->
 
     if hoursAgo < now.getHours()
       if hoursAgo.toFixed() == "1"
-        rDate = "today, one hour ago"
+        rDate = "one hour ago"
       else
-        rDate = "today, #{ hoursAgo.toFixed() } hours ago"
+        rDate = "#{ hoursAgo.toFixed() } hours ago"
 
     if minutesAgo < 60
-      rDate =  "today, #{ minutesAgo.toFixed() } minutes ago"
+      rDate =  "#{ minutesAgo.toFixed() } minutes ago"
 
     if minutesAgo < 2
       rDate = "one minute ago"

--- a/src/less/sections.less
+++ b/src/less/sections.less
@@ -2,5 +2,6 @@ section.dark {
     background: @dark-section-bg;
     color: @dark-section-fg;
     border-top: 0;
-    padding: 20px 0 40px;
+    padding-top: 20px;
+    padding-bottom:40px;
 }

--- a/test/steps/unit/filters-spec.coffee
+++ b/test/steps/unit/filters-spec.coffee
@@ -1,0 +1,57 @@
+define ['angularMocks', 'filters'], (mocks) ->
+
+describe 'Filters', ->
+  'use strict'
+  test = {}
+  beforeEach ->
+    module 'steps.filters'
+    inject (_$filter_) ->
+      test.$filter = _$filter_
+      test.historyTime = new Date()
+
+  it 'should not append a rough date to the day before yesterday', ->
+    twoDaysAgo = test.historyTime.setDate(test.historyTime.getDate()-2);
+    formattedDate = test.$filter('date')(twoDaysAgo)
+    result = test.$filter('roughDate')(twoDaysAgo)
+    # Assert.
+    expect(result).toEqual formattedDate
+
+  it 'should append "a moment ago" to dates less than 1 minute ago.', ->
+    thirtySecsAgo = test.historyTime.setSeconds(test.historyTime.getSeconds()-30)
+    formattedDate = test.$filter('date')(thirtySecsAgo)
+    result = test.$filter('roughDate')(thirtySecsAgo)
+
+    expect(result).toEqual formattedDate + ' (a moment ago)'
+
+  it 'should append "one minute ago" to anything less than two minutes ago.', ->
+    lessThanTwoMinsAgo = test.historyTime.setSeconds(test.historyTime.getSeconds()-110)
+    formattedDate = test.$filter('date')(lessThanTwoMinsAgo)
+    result = test.$filter('roughDate')(lessThanTwoMinsAgo)
+
+    expect(result).toEqual formattedDate + ' (one minute ago)'
+
+  it 'should append "x minutes ago" to anything less than an hour and more than two minutes ago.', ->
+    someTimeAgo = test.historyTime.setMinutes(test.historyTime.getMinutes()-33)
+    formattedDate = test.$filter('date')(someTimeAgo)
+    result = test.$filter('roughDate')(someTimeAgo)
+
+    expect(result).toEqual formattedDate + ' (33 minutes ago)'
+
+  it 'should append "x hours ago" to anything after midnight last night and more than an hour ago.', ->
+    someTimeAgo = test.historyTime.setHours(test.historyTime.getHours()-2)
+    formattedDate = test.$filter('date')(someTimeAgo)
+    result = test.$filter('roughDate')(someTimeAgo)
+
+    expect(result).toEqual formattedDate + ' (2 hours ago)'
+
+  #We test the first second of yesterday. Otherwise this test could fail depending on the time of day it's run.
+  #Hopefully we'll never encounter the possible scenario of running this test at midnight and it failing? There's only a second window where this could happen.
+  it 'should append "yesterday" to anything that does not meet the categories above and is before midnight yesterday', ->
+    test.historyTime.setDate(test.historyTime.getDate()-1)
+    test.historyTime.setHours(0)
+    someTimeAgo = test.historyTime.setMinutes(0)
+    someTimeAgo = test.historyTime.setMinutes(1)
+    formattedDate = test.$filter('date')(someTimeAgo)
+    result = test.$filter('roughDate')(someTimeAgo)
+
+    expect(result).toEqual formattedDate + ' (yesterday)'

--- a/test/steps/unit/filters-spec.coffee
+++ b/test/steps/unit/filters-spec.coffee
@@ -2,56 +2,67 @@ define ['angularMocks', 'filters'], (mocks) ->
 
 describe 'Filters', ->
   'use strict'
+
   test = {}
+
   beforeEach ->
     module 'steps.filters'
     inject (_$filter_) ->
       test.$filter = _$filter_
+
+  describe 'roughDate', ->
+    beforeEach ->
       test.historyTime = new Date()
 
-  it 'should not append a rough date to the day before yesterday', ->
-    twoDaysAgo = test.historyTime.setDate(test.historyTime.getDate()-2);
-    formattedDate = test.$filter('date')(twoDaysAgo)
-    result = test.$filter('roughDate')(twoDaysAgo)
-    # Assert.
-    expect(result).toEqual formattedDate
+    it 'should not append a rough date to the day before yesterday', ->
+      twoDaysAgo = test.historyTime.setDate(test.historyTime.getDate()-2);
+      formattedDate = test.$filter('imDate')(twoDaysAgo)
+      result = test.$filter('roughDate')(twoDaysAgo)
+      # Assert.
+      expect(result).toEqual formattedDate
 
-  it 'should append "a moment ago" to dates less than 1 minute ago.', ->
-    thirtySecsAgo = test.historyTime.setSeconds(test.historyTime.getSeconds()-30)
-    formattedDate = test.$filter('date')(thirtySecsAgo)
-    result = test.$filter('roughDate')(thirtySecsAgo)
+    it 'should append "a moment ago" to dates less than 1 minute ago.', ->
+      thirtySecsAgo = test.historyTime.setSeconds(test.historyTime.getSeconds()-30)
+      formattedDate = test.$filter('imDate')(thirtySecsAgo)
+      result = test.$filter('roughDate')(thirtySecsAgo)
 
-    expect(result).toEqual formattedDate + ' (a moment ago)'
+      expect(result).toEqual formattedDate + ' (a moment ago)'
 
-  it 'should append "one minute ago" to anything less than two minutes ago.', ->
-    lessThanTwoMinsAgo = test.historyTime.setSeconds(test.historyTime.getSeconds()-110)
-    formattedDate = test.$filter('date')(lessThanTwoMinsAgo)
-    result = test.$filter('roughDate')(lessThanTwoMinsAgo)
+    it 'should append "one minute ago" to anything less than two minutes ago.', ->
+      lessThanTwoMinsAgo = test.historyTime.setSeconds(test.historyTime.getSeconds()-110)
+      formattedDate = test.$filter('imDate')(lessThanTwoMinsAgo)
+      result = test.$filter('roughDate')(lessThanTwoMinsAgo)
 
-    expect(result).toEqual formattedDate + ' (one minute ago)'
+      expect(result).toEqual formattedDate + ' (one minute ago)'
 
-  it 'should append "x minutes ago" to anything less than an hour and more than two minutes ago.', ->
-    someTimeAgo = test.historyTime.setMinutes(test.historyTime.getMinutes()-33)
-    formattedDate = test.$filter('date')(someTimeAgo)
-    result = test.$filter('roughDate')(someTimeAgo)
+    it 'should append "x minutes ago" to anything less than an hour and more than two minutes ago.', ->
+      someTimeAgo = test.historyTime.setMinutes(test.historyTime.getMinutes()-33)
+      formattedDate = test.$filter('imDate')(someTimeAgo)
+      result = test.$filter('roughDate')(someTimeAgo)
 
-    expect(result).toEqual formattedDate + ' (33 minutes ago)'
+      expect(result).toEqual formattedDate + ' (33 minutes ago)'
 
-  it 'should append "x hours ago" to anything after midnight last night and more than an hour ago.', ->
-    someTimeAgo = test.historyTime.setHours(test.historyTime.getHours()-2)
-    formattedDate = test.$filter('date')(someTimeAgo)
-    result = test.$filter('roughDate')(someTimeAgo)
+    it 'should append "x hours ago" to anything after midnight last night and more than an hour ago.', ->
+      someTimeAgo = test.historyTime.setHours(test.historyTime.getHours()-2)
+      formattedDate = test.$filter('imDate')(someTimeAgo)
+      result = test.$filter('roughDate')(someTimeAgo)
 
-    expect(result).toEqual formattedDate + ' (2 hours ago)'
+      expect(result).toEqual formattedDate + ' (2 hours ago)'
 
-  #We test the first second of yesterday. Otherwise this test could fail depending on the time of day it's run.
-  #Hopefully we'll never encounter the possible scenario of running this test at midnight and it failing? There's only a second window where this could happen.
-  it 'should append "yesterday" to anything that does not meet the categories above and is before midnight yesterday', ->
-    test.historyTime.setDate(test.historyTime.getDate()-1)
-    test.historyTime.setHours(0)
-    someTimeAgo = test.historyTime.setMinutes(0)
-    someTimeAgo = test.historyTime.setMinutes(1)
-    formattedDate = test.$filter('date')(someTimeAgo)
-    result = test.$filter('roughDate')(someTimeAgo)
+    #We test the first second of yesterday. Otherwise this test could fail depending on the time of day it's run.
+    #Hopefully we'll never encounter the possible scenario of running this test at midnight and it failing? There's only a single second window where this could happen.
+    it 'should append "yesterday" to anything that does not meet the categories above and is before midnight yesterday', ->
+      test.historyTime.setDate(test.historyTime.getDate()-1)
+      test.historyTime.setHours(0)
+      someTimeAgo = test.historyTime.setMinutes(0)
+      someTimeAgo = test.historyTime.setMinutes(1)
+      formattedDate = test.$filter('imDate')(someTimeAgo)
+      result = test.$filter('roughDate')(someTimeAgo)
 
-    expect(result).toEqual formattedDate + ' (yesterday)'
+      expect(result).toEqual formattedDate + ' (yesterday)'
+
+  describe 'imDate', ->
+    it 'should return dates in the format 2014-01-08 13:14', ->
+      reg = /\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}/
+      result = test.$filter('imDate')(new Date())
+      expect(reg.test(result)).toEqual true


### PR DESCRIPTION
Fix for #59

Always states date in YYYY-MM-DD HH:mm format, adds (three hours ago), (yesterday) etc. as appropriate after the date in question, so easier to scan. Doesn't add anything to dates that are longer ago than yesterday.

Also added test cases for the date formatting.